### PR TITLE
fix: Checkbox margin

### DIFF
--- a/refine.css
+++ b/refine.css
@@ -391,7 +391,7 @@ pre, .CodeMirror {
 }
 
 #write input[type="checkbox"] {
-  margin: 0.75rem 0;
+  margin: 0.75rem -1.5rem;
 }
 
 img {


### PR DESCRIPTION
Currently the checkbox is rendered like this:
![Screen Shot 2019-10-06 at 08 02 50](https://user-images.githubusercontent.com/21154023/66262319-cf34ac80-e80f-11e9-82e8-0dec0f992028.png)
As you can see, the text is overlapping with the checkbox.

Excepted result:
![Screen Shot 2019-10-06 at 08 04 44](https://user-images.githubusercontent.com/21154023/66262332-fee3b480-e80f-11e9-96b4-b05435e9c886.png)

Rendered on GitHub:
# Checker Test

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3
  - [ ] Nested Item
- [ ] Item 4